### PR TITLE
Add CI workflow to run module tests and badges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,105 @@
+name: Test Suite
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  interpreter:
+    name: Interpreter Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Export CHROME_BIN
+        run: echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run interpreter tests
+        run: ./gradlew --no-daemon :interpreter:clean :interpreter:allTests
+
+  vm:
+    name: VM Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Export CHROME_BIN
+        run: echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run VM tests
+        run: ./gradlew --no-daemon :vm:clean :vm:allTests
+
+  conformance:
+    name: Conformance Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Export CHROME_BIN
+        run: echo "CHROME_BIN=${{ steps.setup-chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Run conformance tests
+        run: ./gradlew --no-daemon :conformance-tests:clean :conformance-tests:allTests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Branchline: speed, clarity, and tracing for structured data
 
+[![Interpreter Tests](https://github.com/ehlyzov/branchline-public/actions/workflows/tests.yml/badge.svg?branch=main&job=Interpreter%20Tests)](https://github.com/ehlyzov/branchline-public/actions/workflows/tests.yml)
+[![VM Tests](https://github.com/ehlyzov/branchline-public/actions/workflows/tests.yml/badge.svg?branch=main&job=VM%20Tests)](https://github.com/ehlyzov/branchline-public/actions/workflows/tests.yml)
+[![Conformance Tests](https://github.com/ehlyzov/branchline-public/actions/workflows/tests.yml/badge.svg?branch=main&job=Conformance%20Tests)](https://github.com/ehlyzov/branchline-public/actions/workflows/tests.yml)
+
 Branchline is an experimental data transformation language for building efficient pipelines in low-code environments. It focuses on converting one JSON-like document into another while offering tooling to make the process observable, predictable, and fast. Comparisons with JSONATA, JOLT, and similar technologies are planned for the future.
 
 In a practical case (a program of several thousand lines originally written in JSONata), Branchline showed a performance improvement of roughly 30× compared to the excellent [dashjoin/jsonata-java](https://github.com/dashjoin/jsonata-java) implementation. However, this result comes from a single test case; comprehensive benchmarks have not been conducted, so it is difficult to make general statements about overall performance. Theoretically, Branchline should be faster by design, but practical numbers will be published once systematic measurements are carried out.


### PR DESCRIPTION
## Summary
- add `.github/workflows/tests.yml` to execute interpreter, VM, and conformance test suites with Chrome provisioning
- add README badges that surface the status of each module's workflow job

## Testing
- `./gradlew --no-daemon :interpreter:clean :interpreter:allTests --console=plain` *(fails: Kotlin/JS browser tests require a headless Chrome binary in this container)*

------
https://chatgpt.com/codex/tasks/task_e_68de3659c5ac8329b2bc740dcba8f025