### PR TITLE
CLI: Add output/trace/error formatting, deterministic JS bundle, and integration tests

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -121,6 +121,13 @@ tasks.register('prepareJsCliPackage') {
         def pkgFile = new File(targetRoot, 'package.json')
         pkgFile.text = resolved
 
+        def lockTemplate = file("${projectDir}/js-package/package-lock.json.tpl")
+        if (!lockTemplate.exists()) {
+            throw new GradleException("Missing js-package/package-lock.json.tpl; generate it via npm install --package-lock-only.")
+        }
+        def lockResolved = lockTemplate.text.replace('__VERSION__', project.version.toString())
+        new File(targetRoot, 'package-lock.json').text = lockResolved
+
         // Install production dependencies so the packaged CLI ships a self-contained node_modules tree
         def npmExecutable = resolveNpmExecutable()
         if (npmExecutable == null) {
@@ -128,7 +135,7 @@ tasks.register('prepareJsCliPackage') {
         }
         exec {
             workingDir targetRoot
-            commandLine npmExecutable, 'install', '--production', '--ignore-scripts', '--no-audit', '--no-fund'
+            commandLine npmExecutable, 'ci', '--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund'
         }
     }
 }

--- a/cli/js-package/package-lock.json.tpl
+++ b/cli/js-package/package-lock.json.tpl
@@ -1,0 +1,52 @@
+{
+  "name": "branchline-cli-js",
+  "version": "__VERSION__",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "branchline-cli-js",
+      "version": "__VERSION__",
+      "dependencies": {
+        "fast-xml-parser": "4.3.5"
+      },
+      "bin": {
+        "bl": "bin/bl.cjs"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
+      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    }
+  }
+}

--- a/cli/src/commonMain/kotlin/io/branchline/cli/BranchlineCli.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/BranchlineCli.kt
@@ -24,42 +24,51 @@ import v2.contract.SchemaRequirement
 import v2.contract.TransformContract
 import v2.contract.TransformContractBuilder
 import v2.contract.ValueShape
+import v2.debug.CollectingTracer
+import v2.debug.TraceOptions
+import v2.debug.TraceReport
+import v2.debug.humanize
 import v2.sema.SemanticAnalyzer
 import v2.sema.SemanticWarning
 import v2.sema.TypeResolver
 import v2.std.StdLib
 import v2.vm.BytecodeIO
 
-enum class PlatformKind { JVM, JS }
+public enum class PlatformKind { JVM, JS }
 
-enum class InputFormat { JSON, XML;
+public enum class InputFormat { JSON, XML;
     companion object {
         fun parse(value: String): InputFormat = when (value.lowercase()) {
             "json" -> JSON
             "xml" -> XML
-            else -> throw CliException("Unknown input format '$value'")
+            else -> throw CliException("Unknown input format '$value'", kind = CliErrorKind.USAGE)
         }
     }
 }
 
-data class RunOptions(
+public data class RunOptions(
     val scriptPath: String,
     val inputPath: String?,
     val inputFormat: InputFormat,
     val transformName: String?,
+    val outputFormat: OutputFormat,
+    val traceFormat: TraceFormat?,
 )
 
-data class CompileOptions(
+public data class CompileOptions(
     val scriptPath: String,
     val outputPath: String?,
     val transformName: String?,
+    val outputFormat: OutputFormat,
 )
 
-data class ExecOptions(
+public data class ExecOptions(
     val artifactPath: String,
     val inputPath: String?,
     val inputFormat: InputFormat,
     val transformOverride: String?,
+    val outputFormat: OutputFormat,
+    val traceFormat: TraceFormat?,
 )
 
 public data class InspectOptions(
@@ -86,31 +95,66 @@ public data class ContractDiffOptions(
 
 public enum class CliCommand { RUN, COMPILE, EXECUTE, INSPECT, SCHEMA, CONTRACT_DIFF }
 
-object BranchlineCli {
+public object BranchlineCli {
     fun run(args: List<String>, platform: PlatformKind, defaultCommand: CliCommand? = null): Int {
         if (args.isEmpty()) {
             printHelp(defaultCommand)
-            return 1
+            return ExitCode.USAGE.code
         }
-        if (args.size == 1 && (args[0] == "--help" || args[0] == "-h" || args[0] == "help")) {
+
+        val (normalizedArgs, globalOptions) = try {
+            parseGlobalOptions(args)
+        } catch (ex: CliException) {
+            return handleCliError(
+                CliError(ex.message ?: "CLI error", ex.kind, null),
+                ErrorFormat.TEXT,
+            )
+        }
+
+        if (normalizedArgs.isEmpty()) {
             printHelp(defaultCommand)
-            return 0
+            return ExitCode.USAGE.code
         }
+
+        if (normalizedArgs.size == 1 && (normalizedArgs[0] == "--help" || normalizedArgs[0] == "-h" || normalizedArgs[0] == "help")) {
+            printHelp(defaultCommand)
+            return ExitCode.SUCCESS.code
+        }
+        if (normalizedArgs.size == 1 && (normalizedArgs[0] == "--version" || normalizedArgs[0] == "-v")) {
+            printVersion()
+            return ExitCode.SUCCESS.code
+        }
+
+        val errorFormat = globalOptions.errorFormat
 
         val parseResult = try {
-            parseArgs(args, defaultCommand)
+            parseArgs(normalizedArgs, defaultCommand)
         } catch (ex: CliException) {
-            printError(ex.message ?: "CLI error")
-            return 1
+            return handleCliError(
+                CliError(ex.message ?: "CLI error", ex.kind, null),
+                errorFormat,
+            )
         }
 
-        return when (val command = parseResult.command) {
-            CliCommand.RUN -> executeRun(parseResult.run!!, platform)
-            CliCommand.COMPILE -> executeCompile(parseResult.compile!!)
-            CliCommand.EXECUTE -> executeExec(parseResult.exec!!)
-            CliCommand.INSPECT -> executeInspect(parseResult.inspect!!)
-            CliCommand.SCHEMA -> executeSchema(parseResult.schema!!)
-            CliCommand.CONTRACT_DIFF -> executeContractDiff(parseResult.contractDiff!!)
+        return try {
+            when (val command = parseResult.command) {
+                CliCommand.RUN -> executeRun(parseResult.run!!, platform)
+                CliCommand.COMPILE -> executeCompile(parseResult.compile!!)
+                CliCommand.EXECUTE -> executeExec(parseResult.exec!!)
+                CliCommand.INSPECT -> executeInspect(parseResult.inspect!!)
+                CliCommand.SCHEMA -> executeSchema(parseResult.schema!!)
+                CliCommand.CONTRACT_DIFF -> executeContractDiff(parseResult.contractDiff!!)
+            }
+        } catch (ex: CliException) {
+            handleCliError(
+                CliError(ex.message ?: "CLI error", ex.kind, parseResult.command),
+                errorFormat,
+            )
+        } catch (ex: Exception) {
+            handleCliError(
+                CliError(ex.message ?: ex.toString(), CliErrorKind.RUNTIME, parseResult.command),
+                errorFormat,
+            )
         }
     }
 
@@ -129,9 +173,9 @@ object BranchlineCli {
             Branchline CLI$defaultHint
             
             Usage:
-              bl [run] <script.bl> [--input <path>|-] [--input-format json|xml] [--transform <name>]
-              blc <script.bl> [--output <artifact.blc>] [--transform <name>]
-              blvm <artifact.blc> [--input <path>|-] [--input-format json|xml] [--transform <name>]
+              bl [run] <script.bl> [--input <path>|-] [--input-format json|xml] [--transform <name>] [--output-format json|json-compact] [--trace] [--trace-format text|json]
+              blc <script.bl> [--output <artifact.blc>] [--transform <name>] [--output-format json|json-compact]
+              blvm <artifact.blc> [--input <path>|-] [--input-format json|xml] [--transform <name>] [--output-format json|json-compact] [--trace] [--trace-format text|json]
               bl inspect <script.bl> --contracts [--transform <name>]
               bl schema <script.bl> <TYPE_NAME> [--nullable] [--output <schema.json>]
               bl schema <script.bl> --all [--nullable] [--output <schema.json>]
@@ -151,12 +195,17 @@ object BranchlineCli {
               --input-format FMT  'json' (default) or 'xml'.
               --transform NAME    Choose a TRANSFORM block by name; defaults to the first transform in the script.
               --output PATH       (compile) write the compiled artifact to PATH. Prints to stdout when omitted.
+              --output-format FMT Format for CLI JSON output ('json' or 'json-compact').
+              --trace             Emit a trace summary to stderr after execution.
+              --trace-format FMT  Trace output format ('text' or 'json').
+              --error-format FMT  Error output format ('text' or 'json').
               --contracts         (inspect) print explicit vs inferred contracts with mismatch warnings.
               --all               (schema) emit a ${'$'}defs block with all TYPE declarations.
               --nullable          (schema) use 'nullable: true' instead of 'type: [\"null\", ...]'.
               --import PATH       (schema) read a JSON Schema document and emit TYPE declarations.
               --name NAME         (schema) name for the imported schema's TYPE declaration.
               --type NAME         (contract-diff) TYPE declaration name when comparing Branchline scripts.
+              --version           Print the CLI version.
             
             Examples:
               bl examples/hello.bl --input fixtures/hello.json
@@ -173,152 +222,116 @@ object BranchlineCli {
     }
 
     private fun executeRun(options: RunOptions, platform: PlatformKind): Int {
-        return try {
-            val source = readTextFile(options.scriptPath)
-            val runtime = BranchlineProgram(source)
-            val transform = runtime.selectTransform(options.transformName)
-            val input = loadInput(options.inputPath, options.inputFormat)
-            val result = runtime.execute(transform, input)
-            println(formatJson(result, pretty = true))
-            0
-        } catch (ex: CliException) {
-            printError(ex.message ?: "CLI error")
-            1
-        } catch (ex: Exception) {
-            printError(ex.message ?: ex.toString())
-            1
-        }
+        val traceSession = createTraceSession(options.traceFormat)
+        val source = readTextFileOrThrow(options.scriptPath)
+        val runtime = BranchlineProgram(source, traceSession?.tracer)
+        val transform = runtime.selectTransform(options.transformName)
+        val input = loadInput(options.inputPath, options.inputFormat)
+        val result = runtime.execute(transform, input)
+        println(formatJson(result, pretty = options.outputFormat.pretty))
+        traceSession?.emit()
+        return ExitCode.SUCCESS.code
     }
 
     private fun executeCompile(options: CompileOptions): Int {
-        return try {
-            val source = readTextFile(options.scriptPath)
-            val runtime = BranchlineProgram(source)
-            val transform = runtime.selectTransform(options.transformName)
-            val contract = runtime.contractForTransform(transform)
-            val bytecode = runtime.compileBytecode(transform)
-            val artifact = CompiledArtifact(
-                version = 1,
-                transform = transform.name,
-                script = source,
-                bytecode = BytecodeIO.serializeBytecode(bytecode),
-                contract = contract,
-            )
-            val payload = ArtifactCodec.encode(artifact)
-            if (options.outputPath != null) {
-                writeTextFile(options.outputPath, payload)
-            } else {
-                println(payload)
-            }
-            0
-        } catch (ex: CliException) {
-            printError(ex.message ?: "CLI error")
-            1
-        } catch (ex: Exception) {
-            printError(ex.message ?: ex.toString())
-            1
+        val source = readTextFileOrThrow(options.scriptPath)
+        val runtime = BranchlineProgram(source)
+        val transform = runtime.selectTransform(options.transformName)
+        val contract = runtime.contractForTransform(transform)
+        val bytecode = runtime.compileBytecode(transform)
+        val artifact = CompiledArtifact(
+            version = 1,
+            transform = transform.name,
+            script = source,
+            bytecode = BytecodeIO.serializeBytecode(bytecode),
+            contract = contract,
+        )
+        val payload = ArtifactCodec.encode(artifact, pretty = options.outputFormat.pretty)
+        if (options.outputPath != null) {
+            writeTextFileOrThrow(options.outputPath, payload)
+        } else {
+            println(payload)
         }
+        return ExitCode.SUCCESS.code
     }
 
     private fun executeExec(options: ExecOptions): Int {
-        return try {
-            val raw = readTextFile(options.artifactPath)
-            val artifact = ArtifactCodec.decode(raw)
-            val runtime = BranchlineProgram(artifact.script)
-            val transformName = options.transformOverride ?: artifact.transform
-            val transform = runtime.selectTransform(transformName)
-            val bytecode = BytecodeIO.deserializeBytecode(artifact.bytecode)
-            val vmExec = runtime.prepareVmExec(transform, bytecode)
-            val input = loadInput(options.inputPath, options.inputFormat)
-            val env = HashMap<String, Any?>(input.size + 1).apply {
-                this[v2.DEFAULT_INPUT_ALIAS] = input
-                putAll(input)
-                for (alias in v2.COMPAT_INPUT_ALIASES) {
-                    this[alias] = input
-                }
+        val traceSession = createTraceSession(options.traceFormat)
+        val raw = readTextFileOrThrow(options.artifactPath)
+        val artifact = ArtifactCodec.decode(raw)
+        val runtime = BranchlineProgram(artifact.script, traceSession?.tracer)
+        val transformName = options.transformOverride ?: artifact.transform
+        val transform = runtime.selectTransform(transformName)
+        val bytecode = BytecodeIO.deserializeBytecode(artifact.bytecode)
+        val vmExec = runtime.prepareVmExec(transform, bytecode)
+        val input = loadInput(options.inputPath, options.inputFormat)
+        val env = HashMap<String, Any?>(input.size + 1).apply {
+            this[v2.DEFAULT_INPUT_ALIAS] = input
+            putAll(input)
+            for (alias in v2.COMPAT_INPUT_ALIASES) {
+                this[alias] = input
             }
-            val result = vmExec.run(env as MutableMap<String, Any?>, stringifyKeys = true)
-            println(formatJson(result, pretty = true))
-            0
-        } catch (ex: CliException) {
-            printError(ex.message ?: "CLI error")
-            1
-        } catch (ex: Exception) {
-            printError(ex.message ?: ex.toString())
-            1
         }
+        val result = vmExec.run(env as MutableMap<String, Any?>, stringifyKeys = true)
+        println(formatJson(result, pretty = options.outputFormat.pretty))
+        traceSession?.emit()
+        return ExitCode.SUCCESS.code
     }
 
     private fun executeInspect(options: InspectOptions): Int {
-        return try {
-            if (!options.showContracts) {
-                throw CliException("Inspect requires --contracts")
-            }
-            val source = readTextFile(options.scriptPath)
-            val tokens = Lexer(source).lex()
-            val program = Parser(tokens, source).parse()
-            val hostFns = StdLib.fns
-            val analyzer = SemanticAnalyzer(hostFns.keys)
-            analyzer.analyze(program)
-            val transforms = program.decls.filterIsInstance<TransformDecl>()
-            if (transforms.isEmpty()) {
-                throw CliException("Program must declare at least one TRANSFORM block")
-            }
-            val typeDecls = program.decls.filterIsInstance<TypeDecl>()
-            val contractBuilder = TransformContractBuilder(TypeResolver(typeDecls), hostFns.keys)
-            val selected = selectTransforms(transforms, options.transformName)
-            val report = renderContractInspection(selected, contractBuilder, analyzer.warnings)
-            println(report)
-            0
-        } catch (ex: CliException) {
-            printError(ex.message ?: "CLI error")
-            1
-        } catch (ex: Exception) {
-            printError(ex.message ?: ex.toString())
-            1
+        if (!options.showContracts) {
+            throw CliException("Inspect requires --contracts", kind = CliErrorKind.USAGE)
         }
+        val source = readTextFileOrThrow(options.scriptPath)
+        val tokens = Lexer(source).lex()
+        val program = Parser(tokens, source).parse()
+        val hostFns = StdLib.fns
+        val analyzer = SemanticAnalyzer(hostFns.keys)
+        analyzer.analyze(program)
+        val transforms = program.decls.filterIsInstance<TransformDecl>()
+        if (transforms.isEmpty()) {
+            throw CliException("Program must declare at least one TRANSFORM block", kind = CliErrorKind.INPUT)
+        }
+        val typeDecls = program.decls.filterIsInstance<TypeDecl>()
+        val contractBuilder = TransformContractBuilder(TypeResolver(typeDecls), hostFns.keys)
+        val selected = selectTransforms(transforms, options.transformName)
+        val report = renderContractInspection(selected, contractBuilder, analyzer.warnings)
+        println(report)
+        return ExitCode.SUCCESS.code
     }
 
     private fun executeSchema(options: SchemaOptions): Int {
-        return try {
-            if (options.importPath != null) {
-                val rawSchema = readTextFile(options.importPath)
-                val declarations = JsonSchemaCliInterop.importSchema(
-                    rawSchema = rawSchema,
-                    importName = options.importName!!,
-                    options = options,
-                )
-                val output = declarations.joinToString("\n\n") { renderTypeDecl(it) }
-                if (options.outputPath != null) {
-                    writeTextFile(options.outputPath, output)
-                } else {
-                    println(output)
-                }
+        if (options.importPath != null) {
+            val rawSchema = readTextFileOrThrow(options.importPath)
+            val declarations = JsonSchemaCliInterop.importSchema(
+                rawSchema = rawSchema,
+                importName = options.importName!!,
+                options = options,
+            )
+            val output = declarations.joinToString("\n\n") { renderTypeDecl(it) }
+            if (options.outputPath != null) {
+                writeTextFileOrThrow(options.outputPath, output)
             } else {
-                val scriptPath = options.scriptPath
-                    ?: throw CliException("Script path is required for schema export")
-                val source = readTextFile(scriptPath)
-                val runtime = BranchlineProgram(source)
-                val typeDecls = runtime.typeDecls()
-                val outputSchema = JsonSchemaCliInterop.exportSchema(
-                    typeDecls = typeDecls,
-                    typeName = options.typeName,
-                    options = options,
-                )
-                if (options.outputPath != null) {
-                    writeTextFile(options.outputPath, outputSchema)
-                } else {
-                    println(outputSchema)
-                }
+                println(output)
             }
-            0
-        } catch (ex: CliException) {
-            printError(ex.message ?: "CLI error")
-            1
-        } catch (ex: Exception) {
-            printError(ex.message ?: ex.toString())
-            1
+        } else {
+            val scriptPath = options.scriptPath
+                ?: throw CliException("Script path is required for schema export", kind = CliErrorKind.USAGE)
+            val source = readTextFileOrThrow(scriptPath)
+            val runtime = BranchlineProgram(source)
+            val typeDecls = runtime.typeDecls()
+            val outputSchema = JsonSchemaCliInterop.exportSchema(
+                typeDecls = typeDecls,
+                typeName = options.typeName,
+                options = options,
+            )
+            if (options.outputPath != null) {
+                writeTextFileOrThrow(options.outputPath, outputSchema)
+            } else {
+                println(outputSchema)
+            }
         }
+        return ExitCode.SUCCESS.code
     }
 
     private fun executeContractDiff(options: ContractDiffOptions): Int {
@@ -346,6 +359,46 @@ object BranchlineCli {
         val schema: SchemaOptions? = null,
         val contractDiff: ContractDiffOptions? = null,
     )
+
+    private data class GlobalOptions(
+        val errorFormat: ErrorFormat,
+    )
+
+    private data class TraceSession(
+        val tracer: CollectingTracer,
+        val format: TraceFormat,
+    ) {
+        fun emit() {
+            val payload = renderTrace(tracer, format)
+            if (payload.isNotBlank()) {
+                printTrace(payload)
+            }
+        }
+    }
+
+    private fun parseGlobalOptions(args: List<String>): Pair<List<String>, GlobalOptions> {
+        var errorFormat = ErrorFormat.TEXT
+        val remaining = mutableListOf<String>()
+        var idx = 0
+        while (idx < args.size) {
+            val token = args[idx]
+            when {
+                token == "--error-format" && idx + 1 < args.size -> {
+                    errorFormat = ErrorFormat.parse(args[idx + 1])
+                    idx += 2
+                }
+                token == "--error-format" -> throw CliException(
+                    "--error-format requires a value",
+                    kind = CliErrorKind.USAGE,
+                )
+                else -> {
+                    remaining += token
+                    idx += 1
+                }
+            }
+        }
+        return remaining to GlobalOptions(errorFormat)
+    }
 
     private fun parseArgs(args: List<String>, defaultCommand: CliCommand?): ParsedArgs {
         val (command, startIndex) = determineCommand(args, defaultCommand)
@@ -381,6 +434,8 @@ object BranchlineCli {
         var input: String? = null
         var transform: String? = null
         var format = InputFormat.JSON
+        var outputFormat = OutputFormat.JSON
+        var traceFormat: TraceFormat? = null
         var idx = startIndex
         while (idx < args.size) {
             val token = args[idx]
@@ -397,6 +452,24 @@ object BranchlineCli {
                     transform = args[idx + 1]
                     idx += 2
                 }
+                token == "--output-format" && idx + 1 < args.size -> {
+                    outputFormat = OutputFormat.parse(args[idx + 1])
+                    idx += 2
+                }
+                token == "--trace" -> {
+                    if (traceFormat == null) {
+                        traceFormat = TraceFormat.TEXT
+                    }
+                    idx += 1
+                }
+                token == "--trace-format" && idx + 1 < args.size -> {
+                    traceFormat = TraceFormat.parse(args[idx + 1])
+                    idx += 2
+                }
+                token == "--trace-format" -> throw CliException(
+                    "--trace-format requires a value",
+                    kind = CliErrorKind.USAGE,
+                )
                 token.startsWith("--") -> throw CliException("Unknown option '$token'")
                 script == null -> {
                     script = token
@@ -406,13 +479,14 @@ object BranchlineCli {
             }
         }
         if (script == null) throw CliException("Script path is required")
-        return RunOptions(script, input, format, transform)
+        return RunOptions(script, input, format, transform, outputFormat, traceFormat)
     }
 
     private fun parseCompileArgs(args: List<String>, startIndex: Int): CompileOptions {
         var script: String? = null
         var output: String? = null
         var transform: String? = null
+        var outputFormat = OutputFormat.JSON
         var idx = startIndex
         while (idx < args.size) {
             val token = args[idx]
@@ -425,6 +499,10 @@ object BranchlineCli {
                     transform = args[idx + 1]
                     idx += 2
                 }
+                token == "--output-format" && idx + 1 < args.size -> {
+                    outputFormat = OutputFormat.parse(args[idx + 1])
+                    idx += 2
+                }
                 token.startsWith("--") -> throw CliException("Unknown option '$token'")
                 script == null -> {
                     script = token
@@ -434,7 +512,7 @@ object BranchlineCli {
             }
         }
         if (script == null) throw CliException("Script path is required")
-        return CompileOptions(script, output, transform)
+        return CompileOptions(script, output, transform, outputFormat)
     }
 
     private fun parseExecArgs(args: List<String>, startIndex: Int): ExecOptions {
@@ -442,6 +520,8 @@ object BranchlineCli {
         var input: String? = null
         var format = InputFormat.JSON
         var transform: String? = null
+        var outputFormat = OutputFormat.JSON
+        var traceFormat: TraceFormat? = null
         var idx = startIndex
         while (idx < args.size) {
             val token = args[idx]
@@ -458,6 +538,24 @@ object BranchlineCli {
                     transform = args[idx + 1]
                     idx += 2
                 }
+                token == "--output-format" && idx + 1 < args.size -> {
+                    outputFormat = OutputFormat.parse(args[idx + 1])
+                    idx += 2
+                }
+                token == "--trace" -> {
+                    if (traceFormat == null) {
+                        traceFormat = TraceFormat.TEXT
+                    }
+                    idx += 1
+                }
+                token == "--trace-format" && idx + 1 < args.size -> {
+                    traceFormat = TraceFormat.parse(args[idx + 1])
+                    idx += 2
+                }
+                token == "--trace-format" -> throw CliException(
+                    "--trace-format requires a value",
+                    kind = CliErrorKind.USAGE,
+                )
                 token.startsWith("--") -> throw CliException("Unknown option '$token'")
                 artifact == null -> {
                     artifact = token
@@ -467,7 +565,7 @@ object BranchlineCli {
             }
         }
         if (artifact == null) throw CliException("Artifact path is required")
-        return ExecOptions(artifact, input, format, transform)
+        return ExecOptions(artifact, input, format, transform, outputFormat, traceFormat)
     }
 
     private fun parseInspectArgs(args: List<String>, startIndex: Int): InspectOptions {
@@ -604,18 +702,59 @@ object BranchlineCli {
             typeName = typeName,
         )
     }
+	private fun printVersion() {
+        println("Branchline CLI ${CliVersion.CURRENT}")
+    }
+
+    private fun createTraceSession(format: TraceFormat?): TraceSession? {
+        if (format == null) return null
+        return TraceSession(
+            tracer = CollectingTracer(TraceOptions()),
+            format = format,
+		)
+	}
 }
 
 private fun loadInput(path: String?, format: InputFormat): Map<String, Any?> {
     val text = when {
         path == null -> ""
-        path == "-" -> readStdin()
-        else -> readTextFile(path)
+        path == "-" -> readStdinOrThrow()
+        else -> readTextFileOrThrow(path)
     }
     if (text.isBlank()) return emptyMap()
-    return when (format) {
-        InputFormat.JSON -> parseJsonInput(text)
-        InputFormat.XML -> parseXmlInput(text)
+    return try {
+        when (format) {
+            InputFormat.JSON -> parseJsonInput(text)
+            InputFormat.XML -> parseXmlInput(text)
+        }
+    } catch (ex: CliException) {
+        throw ex
+    } catch (ex: Exception) {
+        throw CliException(ex.message ?: "Invalid input", kind = CliErrorKind.INPUT)
+    }
+}
+
+private fun readTextFileOrThrow(path: String): String {
+    return try {
+        readTextFile(path)
+    } catch (ex: Exception) {
+        throw CliException("Failed to read file '$path': ${ex.message ?: ex}", kind = CliErrorKind.IO)
+    }
+}
+
+private fun writeTextFileOrThrow(path: String, contents: String) {
+    try {
+        writeTextFile(path, contents)
+    } catch (ex: Exception) {
+        throw CliException("Failed to write file '$path': ${ex.message ?: ex}", kind = CliErrorKind.IO)
+    }
+}
+
+private fun readStdinOrThrow(): String {
+    return try {
+        readStdin()
+    } catch (ex: Exception) {
+        throw CliException("Failed to read stdin: ${ex.message ?: ex}", kind = CliErrorKind.IO)
     }
 }
 
@@ -626,7 +765,7 @@ private fun selectTransforms(
     if (name == null) return transforms
     val matches = transforms.filter { it.name == name }
     if (matches.isEmpty()) {
-        throw CliException("Transform '$name' not found")
+        throw CliException("Transform '$name' not found", kind = CliErrorKind.INPUT)
     }
     return matches
 }
@@ -816,3 +955,74 @@ private fun renderContractWarnings(warnings: List<SemanticWarning>): String {
 
 private fun indentLines(lines: List<String>, indent: String): List<String> =
     lines.map { line -> "$indent$line" }
+
+private fun handleCliError(error: CliError, format: ErrorFormat): Int {
+    val payload = when (format) {
+        ErrorFormat.TEXT -> error.message
+        ErrorFormat.JSON -> formatJson(
+            mapOf(
+                "error" to mapOf(
+                    "message" to error.message,
+                    "kind" to error.kind.id,
+                    "exitCode" to error.kind.exitCode.code,
+                    "command" to error.command?.name?.lowercase(),
+                ),
+                "version" to CliVersion.CURRENT,
+            ),
+            pretty = false,
+        )
+    }
+    printError(payload)
+    return error.kind.exitCode.code
+}
+
+private fun renderTrace(tracer: CollectingTracer, format: TraceFormat): String {
+    return when (format) {
+        TraceFormat.TEXT -> tracer.humanize("Trace")
+        TraceFormat.JSON -> {
+            val report = TraceReport.from(tracer)
+            formatJson(traceReportToMap(report), pretty = false)
+        }
+    }
+}
+
+private fun traceReportToMap(report: TraceReport.TraceReportData): Map<String, Any?> {
+    val timelineSample = report.timelineSample.map { entry ->
+        mapOf(
+            "at" to entry.at.toString(),
+            "kind" to entry.kind,
+            "label" to entry.label,
+        )
+    }
+    val hotspots = report.hotspots.map { hotspot ->
+        mapOf(
+            "kind" to hotspot.kind,
+            "name" to hotspot.name,
+            "calls" to hotspot.calls,
+            "total" to hotspot.total.toString(),
+            "mean" to hotspot.mean.toString(),
+        )
+    }
+    val watches = report.watches.mapValues { (_, info) ->
+        mapOf(
+            "last" to info.last,
+            "changes" to info.changes,
+        )
+    }
+    val checkpoints = report.checkpoints.map { checkpoint ->
+        mapOf(
+            "at" to checkpoint.at.toString(),
+            "label" to checkpoint.label,
+        )
+    }
+    return mapOf(
+        "totalEvents" to report.totalEvents,
+        "duration" to report.duration.toString(),
+        "timelineSample" to timelineSample,
+        "hotspots" to hotspots,
+        "watches" to watches,
+        "checkpoints" to checkpoints,
+        "explanations" to report.explanations,
+        "instructions" to report.instructions,
+    )
+}

--- a/cli/src/commonMain/kotlin/io/branchline/cli/CliFormatting.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/CliFormatting.kt
@@ -1,0 +1,61 @@
+package io.branchline.cli
+
+public enum class OutputFormat(val id: String, val pretty: Boolean) {
+    JSON("json", true),
+    JSON_COMPACT("json-compact", false);
+
+    companion object {
+        fun parse(value: String): OutputFormat = when (value.lowercase()) {
+            "json" -> JSON
+            "json-compact", "json_compact" -> JSON_COMPACT
+            else -> throw CliException("Unknown output format '$value'", kind = CliErrorKind.USAGE)
+        }
+    }
+}
+
+public enum class ErrorFormat(val id: String) {
+    TEXT("text"),
+    JSON("json");
+
+    companion object {
+        fun parse(value: String): ErrorFormat = when (value.lowercase()) {
+            "text" -> TEXT
+            "json" -> JSON
+            else -> throw CliException("Unknown error format '$value'", kind = CliErrorKind.USAGE)
+        }
+    }
+}
+
+public enum class TraceFormat(val id: String) {
+    TEXT("text"),
+    JSON("json");
+
+    companion object {
+        fun parse(value: String): TraceFormat = when (value.lowercase()) {
+            "text" -> TEXT
+            "json" -> JSON
+            else -> throw CliException("Unknown trace format '$value'", kind = CliErrorKind.USAGE)
+        }
+    }
+}
+
+public enum class ExitCode(val code: Int) {
+    SUCCESS(0),
+    USAGE(64),
+    INPUT(65),
+    IO(74),
+    RUNTIME(70),
+}
+
+public enum class CliErrorKind(val id: String, val exitCode: ExitCode) {
+    USAGE("usage", ExitCode.USAGE),
+    INPUT("input", ExitCode.INPUT),
+    IO("io", ExitCode.IO),
+    RUNTIME("runtime", ExitCode.RUNTIME),
+}
+
+public data class CliError(
+    val message: String,
+    val kind: CliErrorKind,
+    val command: CliCommand?,
+)

--- a/cli/src/commonMain/kotlin/io/branchline/cli/CliVersion.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/CliVersion.kt
@@ -1,0 +1,5 @@
+package io.branchline.cli
+
+public object CliVersion {
+    const val CURRENT = "v0.9.1-alpha"
+}

--- a/cli/src/commonMain/kotlin/io/branchline/cli/PlatformIO.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/PlatformIO.kt
@@ -1,11 +1,13 @@
 package io.branchline.cli
 
-expect fun readTextFile(path: String): String
+public expect fun readTextFile(path: String): String
 
-expect fun writeTextFile(path: String, contents: String)
+public expect fun writeTextFile(path: String, contents: String)
 
-expect fun readStdin(): String
+public expect fun readStdin(): String
 
-expect fun printError(message: String)
+public expect fun printError(message: String)
 
-expect fun parseXmlInput(text: String): Map<String, Any?>
+public expect fun printTrace(message: String)
+
+public expect fun parseXmlInput(text: String): Map<String, Any?>

--- a/cli/src/commonMain/kotlin/io/branchline/cli/SchemaInterop.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/SchemaInterop.kt
@@ -21,11 +21,11 @@ public object JsonSchemaCliInterop {
         options: SchemaOptions,
     ): String {
         if (typeDecls.isEmpty()) {
-            throw CliException("No TYPE declarations found in the script")
+            throw CliException("No TYPE declarations found in the script", kind = CliErrorKind.INPUT)
         }
         val declsByName = typeDecls.associateBy { it.name }
         if (!options.allTypes && typeName != null && !declsByName.containsKey(typeName)) {
-            throw CliException("TYPE '$typeName' not found in the script")
+            throw CliException("TYPE '$typeName' not found in the script", kind = CliErrorKind.INPUT)
         }
         val schemaOptions = JsonSchemaOptions(nullabilityStyle = options.nullabilityStyle)
         val defs = LinkedHashMap<String, JsonElement>(declsByName.size)
@@ -48,7 +48,8 @@ public object JsonSchemaCliInterop {
         options: SchemaOptions,
     ): List<TypeDecl> {
         val element = json.parseToJsonElement(rawSchema)
-        val schema = element as? JsonObject ?: throw CliException("Schema must be a JSON object")
+        val schema = element as? JsonObject
+            ?: throw CliException("Schema must be a JSON object", kind = CliErrorKind.INPUT)
         val schemaOptions = JsonSchemaOptions(nullabilityStyle = options.nullabilityStyle)
         val defs = resolveDefinitions(schema)
         val typeDecls = LinkedHashMap<String, TypeDecl>()
@@ -96,11 +97,12 @@ private fun decodeSchemaDecl(
 ): TypeDecl = try {
     JsonSchemaCodec.decodeTypeDecl(name, schema, options)
 } catch (ex: JsonSchemaException) {
-    throw CliException(ex.message ?: "Schema import failed")
+    throw CliException(ex.message ?: "Schema import failed", kind = CliErrorKind.INPUT)
 }
 
 private fun extractRefName(ref: JsonElement): String {
-    val raw = (ref as? JsonPrimitive)?.content ?: throw CliException("Schema \$ref must be a string")
+    val raw = (ref as? JsonPrimitive)?.content
+        ?: throw CliException("Schema \$ref must be a string", kind = CliErrorKind.INPUT)
     val trimmed = raw.removePrefix("#/")
     return trimmed.split('/').last()
 }

--- a/cli/src/jsMain/kotlin/io/branchline/cli/JsPlatform.kt
+++ b/cli/src/jsMain/kotlin/io/branchline/cli/JsPlatform.kt
@@ -10,10 +10,10 @@ private val fs: dynamic = js("require('fs')")
 private val pathModule: dynamic = js("require('path')")
 private fun newXmlParser(): dynamic = js("(function(){var parserModule=require('fast-xml-parser');return new parserModule.XMLParser({ignoreAttributes:false,attributeNamePrefix:'@',textNodeName:'#text',trimValues:true,parseTagValue:false,parseAttributeValue:false});})()")
 
-actual fun readTextFile(path: String): String =
+public actual fun readTextFile(path: String): String =
     fs.readFileSync(path, "utf8") as String
 
-actual fun writeTextFile(path: String, contents: String) {
+public actual fun writeTextFile(path: String, contents: String) {
     val dir = pathModule.dirname(path)
     if (dir != null && dir as String != "") {
         fs.mkdirSync(dir, json("recursive" to true))
@@ -21,15 +21,19 @@ actual fun writeTextFile(path: String, contents: String) {
     fs.writeFileSync(path, contents, "utf8")
 }
 
-actual fun readStdin(): String {
+public actual fun readStdin(): String {
     return fs.readFileSync(0, "utf8") as String
 }
 
-actual fun printError(message: String) {
+public actual fun printError(message: String) {
     console.error(message)
 }
 
-actual fun parseXmlInput(text: String): Map<String, Any?> {
+public actual fun printTrace(message: String) {
+    console.error(message)
+}
+
+public actual fun parseXmlInput(text: String): Map<String, Any?> {
     if (text.trim().isEmpty()) return emptyMap()
     val parsed = newXmlParser().parse(text)
     val converted = dynamicToKotlin(parsed)

--- a/cli/src/jvmMain/kotlin/io/branchline/cli/JvmPlatform.kt
+++ b/cli/src/jvmMain/kotlin/io/branchline/cli/JvmPlatform.kt
@@ -10,10 +10,10 @@ import javax.xml.parsers.DocumentBuilderFactory
 import org.w3c.dom.Element
 import org.xml.sax.InputSource
 
-actual fun readTextFile(path: String): String =
+public actual fun readTextFile(path: String): String =
     Files.readString(Path.of(path), StandardCharsets.UTF_8)
 
-actual fun writeTextFile(path: String, contents: String) {
+public actual fun writeTextFile(path: String, contents: String) {
     val target = Path.of(path)
     val parent = target.parent
     if (parent != null) {
@@ -22,7 +22,7 @@ actual fun writeTextFile(path: String, contents: String) {
     Files.writeString(target, contents, StandardCharsets.UTF_8)
 }
 
-actual fun readStdin(): String {
+public actual fun readStdin(): String {
     val reader = BufferedReader(InputStreamReader(System.`in`, StandardCharsets.UTF_8))
     return buildString {
         var line: String? = reader.readLine()
@@ -35,11 +35,15 @@ actual fun readStdin(): String {
     }
 }
 
-actual fun printError(message: String) {
+public actual fun printError(message: String) {
     System.err.println(message)
 }
 
-actual fun parseXmlInput(text: String): Map<String, Any?> {
+public actual fun printTrace(message: String) {
+    System.err.println(message)
+}
+
+public actual fun parseXmlInput(text: String): Map<String, Any?> {
     if (text.isBlank()) return emptyMap()
     val factory = DocumentBuilderFactory.newInstance().apply {
         isNamespaceAware = false

--- a/cli/src/jvmTest/kotlin/io/branchline/cli/CliIntegrationTest.kt
+++ b/cli/src/jvmTest/kotlin/io/branchline/cli/CliIntegrationTest.kt
@@ -1,0 +1,150 @@
+package io.branchline.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+public class CliIntegrationTest {
+    @Test
+    fun blRunsFixtureAndEmitsExpectedOutput() {
+        val scriptPath = fixturePath("hello.bl")
+        val inputPath = fixturePath("input.json")
+        val expected = parseJsonInput(fixturePath("expected.json").readText())
+
+        val result = runCli(
+            args = listOf(
+                scriptPath.toString(),
+                "--input",
+                inputPath.toString(),
+                "--output-format",
+                "json-compact",
+            ),
+        )
+
+        assertEquals(ExitCode.SUCCESS.code, result.exitCode)
+        val output = parseJsonInput(result.stdout)
+        assertEquals(expected, output)
+    }
+
+    @Test
+    fun blcCompilesArtifactFromFixture() {
+        val scriptPath = fixturePath("hello.bl")
+        val outputPath = Files.createTempFile("branchline-cli", ".blc")
+        try {
+            val result = runCli(
+                args = listOf(
+                    scriptPath.toString(),
+                    "--output",
+                    outputPath.toString(),
+                    "--output-format",
+                    "json-compact",
+                ),
+                defaultCommand = CliCommand.COMPILE,
+            )
+
+            assertEquals(ExitCode.SUCCESS.code, result.exitCode)
+            val artifactRaw = Files.readString(outputPath, StandardCharsets.UTF_8)
+            val artifact = ArtifactCodec.decode(artifactRaw)
+            val expectedScript = scriptPath.readText().trim()
+            assertEquals("Hello", artifact.transform)
+            assertEquals(expectedScript, artifact.script.trim())
+        } finally {
+            Files.deleteIfExists(outputPath)
+        }
+    }
+
+    @Test
+    fun blvmExecutesCompiledArtifact() {
+        val scriptPath = fixturePath("hello.bl")
+        val inputPath = fixturePath("input.json")
+        val expected = parseJsonInput(fixturePath("expected.json").readText())
+        val outputPath = Files.createTempFile("branchline-cli", ".blc")
+        try {
+            val compileResult = runCli(
+                args = listOf(
+                    scriptPath.toString(),
+                    "--output",
+                    outputPath.toString(),
+                ),
+                defaultCommand = CliCommand.COMPILE,
+            )
+            assertEquals(ExitCode.SUCCESS.code, compileResult.exitCode)
+
+            val execResult = runCli(
+                args = listOf(
+                    outputPath.toString(),
+                    "--input",
+                    inputPath.toString(),
+                    "--output-format",
+                    "json-compact",
+                ),
+                defaultCommand = CliCommand.EXECUTE,
+            )
+
+            assertEquals(ExitCode.SUCCESS.code, execResult.exitCode)
+            val output = parseJsonInput(execResult.stdout)
+            assertEquals(expected, output)
+        } finally {
+            Files.deleteIfExists(outputPath)
+        }
+    }
+
+    @Test
+    fun errorFormatJsonIncludesExitCode() {
+        val result = runCli(
+            args = listOf(
+                "--error-format",
+                "json",
+            ),
+        )
+
+        assertEquals(ExitCode.USAGE.code, result.exitCode)
+        val errorJson = Json.parseToJsonElement(result.stderr).jsonObject
+        val error = errorJson["error"]?.jsonObject
+        requireNotNull(error)
+        assertEquals("usage", error["kind"]?.jsonPrimitive?.content)
+        assertEquals(
+            ExitCode.USAGE.code.toString(),
+            error["exitCode"]?.jsonPrimitive?.content,
+        )
+    }
+
+    private fun runCli(args: List<String>, defaultCommand: CliCommand? = null): CliRunResult {
+        val stdoutStream = ByteArrayOutputStream()
+        val stderrStream = ByteArrayOutputStream()
+        val originalOut = System.out
+        val originalErr = System.err
+        try {
+            System.setOut(PrintStream(stdoutStream, true, StandardCharsets.UTF_8))
+            System.setErr(PrintStream(stderrStream, true, StandardCharsets.UTF_8))
+            val exitCode = BranchlineCli.run(args, PlatformKind.JVM, defaultCommand)
+            return CliRunResult(
+                exitCode = exitCode,
+                stdout = stdoutStream.toString(StandardCharsets.UTF_8),
+                stderr = stderrStream.toString(StandardCharsets.UTF_8),
+            )
+        } finally {
+            System.setOut(originalOut)
+            System.setErr(originalErr)
+        }
+    }
+
+    private fun fixturePath(name: String): Path {
+        val url = requireNotNull(javaClass.getResource("/fixtures/cli/$name"))
+        return Path.of(url.toURI())
+    }
+
+    private data class CliRunResult(
+        val exitCode: Int,
+        val stdout: String,
+        val stderr: String,
+    )
+}

--- a/cli/src/jvmTest/resources/fixtures/cli/expected.json
+++ b/cli/src/jvmTest/resources/fixtures/cli/expected.json
@@ -1,0 +1,1 @@
+{ "greeting": "Hello, Branchline" }

--- a/cli/src/jvmTest/resources/fixtures/cli/hello.bl
+++ b/cli/src/jvmTest/resources/fixtures/cli/hello.bl
@@ -1,0 +1,3 @@
+TRANSFORM Hello {
+    OUTPUT { greeting: "Hello, " + input.name };
+}

--- a/cli/src/jvmTest/resources/fixtures/cli/input.json
+++ b/cli/src/jvmTest/resources/fixtures/cli/input.json
@@ -1,0 +1,1 @@
+{ "name": "Branchline" }

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -13,6 +13,18 @@ The Branchline CLI wraps the interpreter, compiler, and VM APIs. Both JVM and No
 
 Calling a CLI with no arguments now prints a full help screen (`-h`/`--help` also work). All commands accept structured inputs via `--input <path>` and support XML payloads with `--input-format xml`.
 
+**CLI version:** `v0.9.1-alpha` (matches the current Gradle module version).
+
+## Stable flags (output, tracing, errors)
+
+These flags are part of the stable CLI surface for automation and CI:
+
+- `--output-format json|json-compact` — choose pretty or compact JSON for CLI output (applies to `run`, `exec`, and `compile`).
+- `--trace` — emit a trace summary to stderr after execution.
+- `--trace-format text|json` — format the trace summary (`text` for human-readable, `json` for tooling).
+- `--error-format text|json` — format errors for logs or CI parsers.
+- `--version` — print the CLI version.
+
 ## Command modes and when to use them
 
 - **run**: quickest way to try a Branchline script; compiles + executes in one step. Use in dev loops or CI smoke tests.
@@ -23,6 +35,8 @@ Calling a CLI with no arguments now prints a full help screen (`-h`/`--help` als
 Transform selection: all modes default to the first `TRANSFORM` block. Pass `--transform <name>` to pick another.
 
 Input handling: `--input <path>` reads JSON/XML; `--input -` reads stdin so you can pipe data into the CLI. `--input-format xml` parses XML into objects (attributes as `@attr`, text as `#text`).
+
+Output handling: `--output-format json` emits pretty JSON and `--output-format json-compact` emits minified JSON for CI diffs.
 
 ## Copy/paste quickstart
 
@@ -108,3 +122,15 @@ The `bl.cjs` launcher delegates to the compiled Kotlin/JS runtime and respects t
 ## CI smoke test
 
 The CLI JVM test suite now runs a Node-based smoke test to ensure the packaged bundle executes JSON inputs successfully. This guards against regressions in the packaging flow and verifies the Node wrapper stays in sync with the shared CLI surface.
+
+## Exit codes
+
+The CLI uses stable exit codes so CI scripts can distinguish failure modes:
+
+| Exit code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 64 | Usage error (invalid flags, missing arguments) |
+| 65 | Input error (invalid script, schema, or input data) |
+| 70 | Runtime error (execution or unexpected failure) |
+| 74 | I/O error (file or stdin/stdout issues) |

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -45,6 +45,16 @@ cd branchline-public
   # outputs cli/build/distributions/branchline-cli-js-<version>.tgz
   ```
   Unpack the tarball and run `bin/bl.cjs` in CI or from custom tooling.
+
+### Reproducible JS CLI bundle
+- The CLI bundle uses `cli/js-package/package-lock.json.tpl` for deterministic `node_modules` generation.
+- `./gradlew :cli:prepareJsCliPackage` runs `npm ci --omit=dev` against the lockfile and fails if the lockfile and `package.json` are out of sync.
+- To update dependencies, regenerate the lockfile with:
+  ```bash
+  node -e "const fs=require('fs');const v='v0.9.1-alpha';const tpl=fs.readFileSync('cli/js-package/package.json.tpl','utf8');fs.writeFileSync('cli/js-package/package.json',tpl.replace(/__VERSION__/g,v));"
+  npm install --package-lock-only --ignore-scripts --no-audit --no-fund --prefix cli/js-package
+  rm cli/js-package/package.json
+  ```
   
 ## Bring Branchline into your project
 - **During development/CI:** call the Gradle helpers above to run `.bl` scripts directly.


### PR DESCRIPTION
### Motivation

- Make the Node JS CLI bundle reproducible so CI can generate deterministic `node_modules` without network-dependent installs. 
- Expose stable CLI flags for output formatting, tracing, versioning, and structured error formatting to support automation and parsing in CI. 
- Add integration coverage for primary CLI invocation paths (`bl`, `blc`, `blvm`) using fixtures so packaging/behaviour regressions are caught early. 
- Standardize exit codes and structured error payloads so callers can reliably react to usage, input, I/O and runtime failures. 

### Description

- Use a lockfile template and deterministic install in `cli/build.gradle` by adding `cli/js-package/package-lock.json.tpl` and running `npm ci --omit=dev` from the `prepareJsCliPackage` task. 
- Add formatting, tracing and version primitives: new `CliFormatting.kt` and `CliVersion.kt`, plus CLI parsing/handling changes in `BranchlineCli.kt` to support `--output-format`, `--trace`, `--trace-format`, `--error-format`, and `--version`, and to emit structured error JSON. 
- Wire tracing into runtime: `BranchlineProgram` now accepts an optional `Tracer`, `Exec`/`VMExec` are passed the tracer, and platform I/O was extended with `printTrace` in `PlatformIO` plus JVM/JS implementations. 
- Add safe I/O helpers (`readTextFileOrThrow`, `writeTextFileOrThrow`, `readStdinOrThrow`), integration tests and fixtures in `cli/src/jvmTest` (`CliIntegrationTest` + fixtures), and update docs (`docs/guides/cli.md`, `docs/guides/install.md`) describing reproducible JS bundle steps and stable flags. 

### Testing

- Added `CliIntegrationTest` under `cli/src/jvmTest` which exercises `bl`/`blc`/`blvm` paths using the bundled fixtures and asserts JSON output and compiled artifact round-trip. 
- `JsCliBundleSmokeTest` (existing) runs the packaged Node bundle as a smoke check and will be exercised when `jvmTest` depends on `prepareJsCliPackage`. 
- Packaging changes were locally validated by generating a `package-lock.json` template and running `npm --version` to ensure the `prepareJsCliPackage` flow can resolve `npm` in CI. 
- No automated Gradle or JVM tests were executed as part of this change (tests were added but not run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952cc789a3883299f67627913b5de06)