### PR TITLE
Fix CLI error formatting when only global flags

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -121,6 +121,13 @@ tasks.register('prepareJsCliPackage') {
         def pkgFile = new File(targetRoot, 'package.json')
         pkgFile.text = resolved
 
+        def lockTemplate = file("${projectDir}/js-package/package-lock.json.tpl")
+        if (!lockTemplate.exists()) {
+            throw new GradleException("Missing js-package/package-lock.json.tpl; generate it via npm install --package-lock-only.")
+        }
+        def lockResolved = lockTemplate.text.replace('__VERSION__', project.version.toString())
+        new File(targetRoot, 'package-lock.json').text = lockResolved
+
         // Install production dependencies so the packaged CLI ships a self-contained node_modules tree
         def npmExecutable = resolveNpmExecutable()
         if (npmExecutable == null) {
@@ -128,7 +135,7 @@ tasks.register('prepareJsCliPackage') {
         }
         exec {
             workingDir targetRoot
-            commandLine npmExecutable, 'install', '--production', '--ignore-scripts', '--no-audit', '--no-fund'
+            commandLine npmExecutable, 'ci', '--omit=dev', '--ignore-scripts', '--no-audit', '--no-fund'
         }
     }
 }

--- a/cli/js-package/package-lock.json.tpl
+++ b/cli/js-package/package-lock.json.tpl
@@ -1,0 +1,52 @@
+{
+  "name": "branchline-cli-js",
+  "version": "__VERSION__",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "branchline-cli-js",
+      "version": "__VERSION__",
+      "dependencies": {
+        "fast-xml-parser": "4.3.5"
+      },
+      "bin": {
+        "bl": "bin/bl.cjs"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
+      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    }
+  }
+}

--- a/cli/src/commonMain/kotlin/io/branchline/cli/CliFormatting.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/CliFormatting.kt
@@ -1,0 +1,61 @@
+package io.branchline.cli
+
+public enum class OutputFormat(val id: String, val pretty: Boolean) {
+    JSON("json", true),
+    JSON_COMPACT("json-compact", false);
+
+    companion object {
+        fun parse(value: String): OutputFormat = when (value.lowercase()) {
+            "json" -> JSON
+            "json-compact", "json_compact" -> JSON_COMPACT
+            else -> throw CliException("Unknown output format '$value'", kind = CliErrorKind.USAGE)
+        }
+    }
+}
+
+public enum class ErrorFormat(val id: String) {
+    TEXT("text"),
+    JSON("json");
+
+    companion object {
+        fun parse(value: String): ErrorFormat = when (value.lowercase()) {
+            "text" -> TEXT
+            "json" -> JSON
+            else -> throw CliException("Unknown error format '$value'", kind = CliErrorKind.USAGE)
+        }
+    }
+}
+
+public enum class TraceFormat(val id: String) {
+    TEXT("text"),
+    JSON("json");
+
+    companion object {
+        fun parse(value: String): TraceFormat = when (value.lowercase()) {
+            "text" -> TEXT
+            "json" -> JSON
+            else -> throw CliException("Unknown trace format '$value'", kind = CliErrorKind.USAGE)
+        }
+    }
+}
+
+public enum class ExitCode(val code: Int) {
+    SUCCESS(0),
+    USAGE(64),
+    INPUT(65),
+    IO(74),
+    RUNTIME(70),
+}
+
+public enum class CliErrorKind(val id: String, val exitCode: ExitCode) {
+    USAGE("usage", ExitCode.USAGE),
+    INPUT("input", ExitCode.INPUT),
+    IO("io", ExitCode.IO),
+    RUNTIME("runtime", ExitCode.RUNTIME),
+}
+
+public data class CliError(
+    val message: String,
+    val kind: CliErrorKind,
+    val command: CliCommand?,
+)

--- a/cli/src/commonMain/kotlin/io/branchline/cli/CliVersion.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/CliVersion.kt
@@ -1,0 +1,5 @@
+package io.branchline.cli
+
+public object CliVersion {
+    const val CURRENT = "v0.9.1-alpha"
+}

--- a/cli/src/commonMain/kotlin/io/branchline/cli/PlatformIO.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/PlatformIO.kt
@@ -1,11 +1,13 @@
 package io.branchline.cli
 
-expect fun readTextFile(path: String): String
+public expect fun readTextFile(path: String): String
 
-expect fun writeTextFile(path: String, contents: String)
+public expect fun writeTextFile(path: String, contents: String)
 
-expect fun readStdin(): String
+public expect fun readStdin(): String
 
-expect fun printError(message: String)
+public expect fun printError(message: String)
 
-expect fun parseXmlInput(text: String): Map<String, Any?>
+public expect fun printTrace(message: String)
+
+public expect fun parseXmlInput(text: String): Map<String, Any?>

--- a/cli/src/commonMain/kotlin/io/branchline/cli/SchemaInterop.kt
+++ b/cli/src/commonMain/kotlin/io/branchline/cli/SchemaInterop.kt
@@ -21,11 +21,11 @@ public object JsonSchemaCliInterop {
         options: SchemaOptions,
     ): String {
         if (typeDecls.isEmpty()) {
-            throw CliException("No TYPE declarations found in the script")
+            throw CliException("No TYPE declarations found in the script", kind = CliErrorKind.INPUT)
         }
         val declsByName = typeDecls.associateBy { it.name }
         if (!options.allTypes && typeName != null && !declsByName.containsKey(typeName)) {
-            throw CliException("TYPE '$typeName' not found in the script")
+            throw CliException("TYPE '$typeName' not found in the script", kind = CliErrorKind.INPUT)
         }
         val schemaOptions = JsonSchemaOptions(nullabilityStyle = options.nullabilityStyle)
         val defs = LinkedHashMap<String, JsonElement>(declsByName.size)
@@ -48,7 +48,8 @@ public object JsonSchemaCliInterop {
         options: SchemaOptions,
     ): List<TypeDecl> {
         val element = json.parseToJsonElement(rawSchema)
-        val schema = element as? JsonObject ?: throw CliException("Schema must be a JSON object")
+        val schema = element as? JsonObject
+            ?: throw CliException("Schema must be a JSON object", kind = CliErrorKind.INPUT)
         val schemaOptions = JsonSchemaOptions(nullabilityStyle = options.nullabilityStyle)
         val defs = resolveDefinitions(schema)
         val typeDecls = LinkedHashMap<String, TypeDecl>()
@@ -96,11 +97,12 @@ private fun decodeSchemaDecl(
 ): TypeDecl = try {
     JsonSchemaCodec.decodeTypeDecl(name, schema, options)
 } catch (ex: JsonSchemaException) {
-    throw CliException(ex.message ?: "Schema import failed")
+    throw CliException(ex.message ?: "Schema import failed", kind = CliErrorKind.INPUT)
 }
 
 private fun extractRefName(ref: JsonElement): String {
-    val raw = (ref as? JsonPrimitive)?.content ?: throw CliException("Schema \$ref must be a string")
+    val raw = (ref as? JsonPrimitive)?.content
+        ?: throw CliException("Schema \$ref must be a string", kind = CliErrorKind.INPUT)
     val trimmed = raw.removePrefix("#/")
     return trimmed.split('/').last()
 }

--- a/cli/src/jsMain/kotlin/io/branchline/cli/JsPlatform.kt
+++ b/cli/src/jsMain/kotlin/io/branchline/cli/JsPlatform.kt
@@ -10,10 +10,10 @@ private val fs: dynamic = js("require('fs')")
 private val pathModule: dynamic = js("require('path')")
 private fun newXmlParser(): dynamic = js("(function(){var parserModule=require('fast-xml-parser');return new parserModule.XMLParser({ignoreAttributes:false,attributeNamePrefix:'@',textNodeName:'#text',trimValues:true,parseTagValue:false,parseAttributeValue:false});})()")
 
-actual fun readTextFile(path: String): String =
+public actual fun readTextFile(path: String): String =
     fs.readFileSync(path, "utf8") as String
 
-actual fun writeTextFile(path: String, contents: String) {
+public actual fun writeTextFile(path: String, contents: String) {
     val dir = pathModule.dirname(path)
     if (dir != null && dir as String != "") {
         fs.mkdirSync(dir, json("recursive" to true))
@@ -21,15 +21,19 @@ actual fun writeTextFile(path: String, contents: String) {
     fs.writeFileSync(path, contents, "utf8")
 }
 
-actual fun readStdin(): String {
+public actual fun readStdin(): String {
     return fs.readFileSync(0, "utf8") as String
 }
 
-actual fun printError(message: String) {
+public actual fun printError(message: String) {
     console.error(message)
 }
 
-actual fun parseXmlInput(text: String): Map<String, Any?> {
+public actual fun printTrace(message: String) {
+    console.error(message)
+}
+
+public actual fun parseXmlInput(text: String): Map<String, Any?> {
     if (text.trim().isEmpty()) return emptyMap()
     val parsed = newXmlParser().parse(text)
     val converted = dynamicToKotlin(parsed)

--- a/cli/src/jvmMain/kotlin/io/branchline/cli/JvmPlatform.kt
+++ b/cli/src/jvmMain/kotlin/io/branchline/cli/JvmPlatform.kt
@@ -10,10 +10,10 @@ import javax.xml.parsers.DocumentBuilderFactory
 import org.w3c.dom.Element
 import org.xml.sax.InputSource
 
-actual fun readTextFile(path: String): String =
+public actual fun readTextFile(path: String): String =
     Files.readString(Path.of(path), StandardCharsets.UTF_8)
 
-actual fun writeTextFile(path: String, contents: String) {
+public actual fun writeTextFile(path: String, contents: String) {
     val target = Path.of(path)
     val parent = target.parent
     if (parent != null) {
@@ -22,7 +22,7 @@ actual fun writeTextFile(path: String, contents: String) {
     Files.writeString(target, contents, StandardCharsets.UTF_8)
 }
 
-actual fun readStdin(): String {
+public actual fun readStdin(): String {
     val reader = BufferedReader(InputStreamReader(System.`in`, StandardCharsets.UTF_8))
     return buildString {
         var line: String? = reader.readLine()
@@ -35,11 +35,15 @@ actual fun readStdin(): String {
     }
 }
 
-actual fun printError(message: String) {
+public actual fun printError(message: String) {
     System.err.println(message)
 }
 
-actual fun parseXmlInput(text: String): Map<String, Any?> {
+public actual fun printTrace(message: String) {
+    System.err.println(message)
+}
+
+public actual fun parseXmlInput(text: String): Map<String, Any?> {
     if (text.isBlank()) return emptyMap()
     val factory = DocumentBuilderFactory.newInstance().apply {
         isNamespaceAware = false

--- a/cli/src/jvmTest/kotlin/io/branchline/cli/CliIntegrationTest.kt
+++ b/cli/src/jvmTest/kotlin/io/branchline/cli/CliIntegrationTest.kt
@@ -1,0 +1,150 @@
+package io.branchline.cli
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+public class CliIntegrationTest {
+    @Test
+    fun blRunsFixtureAndEmitsExpectedOutput() {
+        val scriptPath = fixturePath("hello.bl")
+        val inputPath = fixturePath("input.json")
+        val expected = parseJsonInput(fixturePath("expected.json").readText())
+
+        val result = runCli(
+            args = listOf(
+                scriptPath.toString(),
+                "--input",
+                inputPath.toString(),
+                "--output-format",
+                "json-compact",
+            ),
+        )
+
+        assertEquals(ExitCode.SUCCESS.code, result.exitCode)
+        val output = parseJsonInput(result.stdout)
+        assertEquals(expected, output)
+    }
+
+    @Test
+    fun blcCompilesArtifactFromFixture() {
+        val scriptPath = fixturePath("hello.bl")
+        val outputPath = Files.createTempFile("branchline-cli", ".blc")
+        try {
+            val result = runCli(
+                args = listOf(
+                    scriptPath.toString(),
+                    "--output",
+                    outputPath.toString(),
+                    "--output-format",
+                    "json-compact",
+                ),
+                defaultCommand = CliCommand.COMPILE,
+            )
+
+            assertEquals(ExitCode.SUCCESS.code, result.exitCode)
+            val artifactRaw = Files.readString(outputPath, StandardCharsets.UTF_8)
+            val artifact = ArtifactCodec.decode(artifactRaw)
+            val expectedScript = scriptPath.readText().trim()
+            assertEquals("Hello", artifact.transform)
+            assertEquals(expectedScript, artifact.script.trim())
+        } finally {
+            Files.deleteIfExists(outputPath)
+        }
+    }
+
+    @Test
+    fun blvmExecutesCompiledArtifact() {
+        val scriptPath = fixturePath("hello.bl")
+        val inputPath = fixturePath("input.json")
+        val expected = parseJsonInput(fixturePath("expected.json").readText())
+        val outputPath = Files.createTempFile("branchline-cli", ".blc")
+        try {
+            val compileResult = runCli(
+                args = listOf(
+                    scriptPath.toString(),
+                    "--output",
+                    outputPath.toString(),
+                ),
+                defaultCommand = CliCommand.COMPILE,
+            )
+            assertEquals(ExitCode.SUCCESS.code, compileResult.exitCode)
+
+            val execResult = runCli(
+                args = listOf(
+                    outputPath.toString(),
+                    "--input",
+                    inputPath.toString(),
+                    "--output-format",
+                    "json-compact",
+                ),
+                defaultCommand = CliCommand.EXECUTE,
+            )
+
+            assertEquals(ExitCode.SUCCESS.code, execResult.exitCode)
+            val output = parseJsonInput(execResult.stdout)
+            assertEquals(expected, output)
+        } finally {
+            Files.deleteIfExists(outputPath)
+        }
+    }
+
+    @Test
+    fun errorFormatJsonIncludesExitCode() {
+        val result = runCli(
+            args = listOf(
+                "--error-format",
+                "json",
+            ),
+        )
+
+        assertEquals(ExitCode.USAGE.code, result.exitCode)
+        val errorJson = Json.parseToJsonElement(result.stderr).jsonObject
+        val error = errorJson["error"]?.jsonObject
+        requireNotNull(error)
+        assertEquals("usage", error["kind"]?.jsonPrimitive?.content)
+        assertEquals(
+            ExitCode.USAGE.code.toString(),
+            error["exitCode"]?.jsonPrimitive?.content,
+        )
+    }
+
+    private fun runCli(args: List<String>, defaultCommand: CliCommand? = null): CliRunResult {
+        val stdoutStream = ByteArrayOutputStream()
+        val stderrStream = ByteArrayOutputStream()
+        val originalOut = System.out
+        val originalErr = System.err
+        try {
+            System.setOut(PrintStream(stdoutStream, true, StandardCharsets.UTF_8))
+            System.setErr(PrintStream(stderrStream, true, StandardCharsets.UTF_8))
+            val exitCode = BranchlineCli.run(args, PlatformKind.JVM, defaultCommand)
+            return CliRunResult(
+                exitCode = exitCode,
+                stdout = stdoutStream.toString(StandardCharsets.UTF_8),
+                stderr = stderrStream.toString(StandardCharsets.UTF_8),
+            )
+        } finally {
+            System.setOut(originalOut)
+            System.setErr(originalErr)
+        }
+    }
+
+    private fun fixturePath(name: String): Path {
+        val url = requireNotNull(javaClass.getResource("/fixtures/cli/$name"))
+        return Path.of(url.toURI())
+    }
+
+    private data class CliRunResult(
+        val exitCode: Int,
+        val stdout: String,
+        val stderr: String,
+    )
+}

--- a/cli/src/jvmTest/resources/fixtures/cli/expected.json
+++ b/cli/src/jvmTest/resources/fixtures/cli/expected.json
@@ -1,0 +1,1 @@
+{ "greeting": "Hello, Branchline" }

--- a/cli/src/jvmTest/resources/fixtures/cli/hello.bl
+++ b/cli/src/jvmTest/resources/fixtures/cli/hello.bl
@@ -1,0 +1,3 @@
+TRANSFORM Hello {
+    OUTPUT { greeting: "Hello, " + input.name };
+}

--- a/cli/src/jvmTest/resources/fixtures/cli/input.json
+++ b/cli/src/jvmTest/resources/fixtures/cli/input.json
@@ -1,0 +1,1 @@
+{ "name": "Branchline" }

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -13,6 +13,18 @@ The Branchline CLI wraps the interpreter, compiler, and VM APIs. Both JVM and No
 
 Calling a CLI with no arguments now prints a full help screen (`-h`/`--help` also work). All commands accept structured inputs via `--input <path>` and support XML payloads with `--input-format xml`.
 
+**CLI version:** `v0.9.1-alpha` (matches the current Gradle module version).
+
+## Stable flags (output, tracing, errors)
+
+These flags are part of the stable CLI surface for automation and CI:
+
+- `--output-format json|json-compact` — choose pretty or compact JSON for CLI output (applies to `run`, `exec`, and `compile`).
+- `--trace` — emit a trace summary to stderr after execution.
+- `--trace-format text|json` — format the trace summary (`text` for human-readable, `json` for tooling).
+- `--error-format text|json` — format errors for logs or CI parsers.
+- `--version` — print the CLI version.
+
 ## Command modes and when to use them
 
 - **run**: quickest way to try a Branchline script; compiles + executes in one step. Use in dev loops or CI smoke tests.
@@ -23,6 +35,8 @@ Calling a CLI with no arguments now prints a full help screen (`-h`/`--help` als
 Transform selection: all modes default to the first `TRANSFORM` block. Pass `--transform <name>` to pick another.
 
 Input handling: `--input <path>` reads JSON/XML; `--input -` reads stdin so you can pipe data into the CLI. `--input-format xml` parses XML into objects (attributes as `@attr`, text as `#text`).
+
+Output handling: `--output-format json` emits pretty JSON and `--output-format json-compact` emits minified JSON for CI diffs.
 
 ## Copy/paste quickstart
 
@@ -108,3 +122,15 @@ The `bl.cjs` launcher delegates to the compiled Kotlin/JS runtime and respects t
 ## CI smoke test
 
 The CLI JVM test suite now runs a Node-based smoke test to ensure the packaged bundle executes JSON inputs successfully. This guards against regressions in the packaging flow and verifies the Node wrapper stays in sync with the shared CLI surface.
+
+## Exit codes
+
+The CLI uses stable exit codes so CI scripts can distinguish failure modes:
+
+| Exit code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 64 | Usage error (invalid flags, missing arguments) |
+| 65 | Input error (invalid script, schema, or input data) |
+| 70 | Runtime error (execution or unexpected failure) |
+| 74 | I/O error (file or stdin/stdout issues) |

--- a/docs/guides/install.md
+++ b/docs/guides/install.md
@@ -45,6 +45,16 @@ cd branchline-public
   # outputs cli/build/distributions/branchline-cli-js-<version>.tgz
   ```
   Unpack the tarball and run `bin/bl.cjs` in CI or from custom tooling.
+
+### Reproducible JS CLI bundle
+- The CLI bundle uses `cli/js-package/package-lock.json.tpl` for deterministic `node_modules` generation.
+- `./gradlew :cli:prepareJsCliPackage` runs `npm ci --omit=dev` against the lockfile and fails if the lockfile and `package.json` are out of sync.
+- To update dependencies, regenerate the lockfile with:
+  ```bash
+  node -e "const fs=require('fs');const v='v0.9.1-alpha';const tpl=fs.readFileSync('cli/js-package/package.json.tpl','utf8');fs.writeFileSync('cli/js-package/package.json',tpl.replace(/__VERSION__/g,v));"
+  npm install --package-lock-only --ignore-scripts --no-audit --no-fund --prefix cli/js-package
+  rm cli/js-package/package.json
+  ```
   
 ## Bring Branchline into your project
 - **During development/CI:** call the Gradle helpers above to run `.bl` scripts directly.


### PR DESCRIPTION
### Motivation
- Ensure `--error-format json` emits valid structured JSON even when only global flags are provided so CI/tools can parse failures reliably.
- The prior behavior printed the help screen for that case which broke JSON parsing in the `CliIntegrationTest` expecting an error payload.
- Align CLI behavior to consistently honor global options (like `--error-format`) before printing help or exiting.
- Keep exit codes and structured error payloads stable for automation and tests.

### Description
- Parse global flags early by calling `parseGlobalOptions` at the start of `BranchlineCli.run` and capture `GlobalOptions` for downstream handling.
- When no command arguments remain after global flag parsing, return a structured error via `handleCliError` that respects the chosen `ErrorFormat` instead of printing help text.
- Ensure `run` uses the parsed `errorFormat` for subsequent parse/exception handling so JSON/text error output is stable and includes fields like `exitCode` and `kind`.
- Minor control-flow cleanup to return `ExitCode.SUCCESS` for explicit `--help`/`--version` and to route exceptions through `handleCliError`.

### Testing
- The `:cli:prepareJsCliPackage` task ran during the rollout and completed (npm install output present).
- `:cli:jvmTest` was executed before this fix and produced 9 tests with 1 failing test (`CliIntegrationTest.errorFormatJsonIncludesExitCode`).
- After applying the fix the test suite was not re-run in this rollout.
- Recommend re-running `./gradlew :cli:jvmTest` to confirm the integration test now passes with the updated error formatting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952cc789a3883299f67627913b5de06)